### PR TITLE
Add simple shopping cart

### DIFF
--- a/src/app/[locale]/layout.js
+++ b/src/app/[locale]/layout.js
@@ -3,6 +3,7 @@ import TranslationsProvider from "@/app/components/TranslationsProvider";
 import localFont from "next/font/local";
 import "./globals.css";
 import BootstrapClient from "@/app/components/BootstripClient";
+import { CartProvider } from "@/app/hooks/useCart";
 
 
 const geistSans = localFont({
@@ -32,7 +33,9 @@ export default async function RootLayout({ params: { locale }, children }) {
           locale={locale}
           resources={resources}
         >
-          {children}
+          <CartProvider>
+            {children}
+          </CartProvider>
         </TranslationsProvider>
         <BootstrapClient />
       </body>

--- a/src/app/[locale]/parent/cart/page.jsx
+++ b/src/app/[locale]/parent/cart/page.jsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useCart } from '@/app/hooks/useCart';
+import money from '@/app/localization/currency';
+import { useTranslation } from 'react-i18next';
+import { useRouter } from 'next/navigation';
+
+export default function CartPage() {
+  const { items, removeItem, clearCart } = useCart();
+  const { t } = useTranslation();
+  const router = useRouter();
+
+  const total = items.reduce((acc, item) => acc + (item.cost || 0), 0);
+
+  const checkout = () => {
+    if (items.length > 0) {
+      router.push('/parent/payment');
+    }
+  };
+
+  return (
+    <div className="home-section mt-4">
+      <h1 className="mb-3">{t('Shopping Cart')}</h1>
+      {items.length === 0 ? (
+        <p>{t('Your cart is empty')}</p>
+      ) : (
+        <>
+          <ul className="list-group mb-3">
+            {items.map((item) => (
+              <li key={item.schedule_id} className="list-group-item d-flex justify-content-between align-items-center">
+                <span>{item.name}</span>
+                <span>{money(item.cost, item.countryCode)}</span>
+                <button className="btn btn-danger btn-sm" onClick={() => removeItem(item.schedule_id)}>{t('Remove')}</button>
+              </li>
+            ))}
+          </ul>
+          <div className="d-flex justify-content-between mb-3">
+            <strong>{t('Total')}</strong>
+            <span>{money(total, items[0]?.countryCode)}</span>
+          </div>
+          <button className="btn btn-primary" onClick={checkout}>{t('Proceed to Checkout')}</button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/[locale]/profile/[franchise_id]/[schedule_id]/checkout/page.jsx
+++ b/src/app/[locale]/profile/[franchise_id]/[schedule_id]/checkout/page.jsx
@@ -4,6 +4,8 @@ import axiosInstance from "@/axios";
 import alert from '@/app/components/SweetAlerts';
 
 import { useState, useEffect, useRef } from "react";
+import AuthService from '@/auth.service';
+import { useCart } from '@/app/hooks/useCart';
 import { useSearchParams, usePathname, useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 import StudentSelection from "../../studentSelect";
@@ -17,6 +19,8 @@ export default function ScheduleCheckout({ params: { franchise_id, schedule_id }
     const router = useRouter();
     const pathname = usePathname();
     const { replace } = useRouter();
+    const { addItem } = useCart();
+    const isLoggedIn = AuthService.isAuthenticated();
     const searchParams = useSearchParams();
     let studentIds = searchParams.get('id')?.split(',') ?? [];
     let status = searchParams.get('redirect_status');
@@ -52,6 +56,8 @@ export default function ScheduleCheckout({ params: { franchise_id, schedule_id }
     const [couponCode, setCouponCode] = useState('');
     const [studentDetails, setStudentDetails] = useState([]);
     const [selectingStudents, setSelectingStudents] = useState(true);
+
+    const isWaitlist = schedule?.availablespots <= 0 && schedule?.waitlist;
 
     const validateCoupon = async () => {
         try {
@@ -584,6 +590,7 @@ export default function ScheduleCheckout({ params: { franchise_id, schedule_id }
                             <div className="d-flex gap-2 flex-column">
                                 {showPaymentGateway() && <MerchantGateWay key={formData['paymentoption']} merchant_id={franchise_id} paymentData={{ ...formData, students: studentIds, coupon: coupon?.couponcode }} cancelAction={() => setFormData({ ...formData, paymentoption: '' })} submitAction={(token) => { tokenEnroll(token) }} />}
                                 {((formData['paymentoption'] == 'cash' || paymentCardSettings?.totalPayable == 0) && showPaymentGateway(false)) && <button className="btn btn-success btn-lg w-100 rounded-0" onClick={enroll}>{t('Enroll Now')}</button>}
+                                {isLoggedIn && !isWaitlist && <button className="btn btn-outline-primary btn-lg w-100 rounded-0" onClick={() => addItem({ schedule_id, franchise_id, name: schedule?.name, cost: schedule?.cost, countryCode: schedule?.countryCode })}>{t('Add to Cart')}</button>}
                             </div>
                         </div>
                     </div>

--- a/src/app/[locale]/profile/[franchise_id]/scheduleCard.jsx
+++ b/src/app/[locale]/profile/[franchise_id]/scheduleCard.jsx
@@ -8,11 +8,13 @@ import { useSearchParams } from 'next/navigation';
 import Calendar from '@/app/components/calendar/Calendar';
 import useClickOutside from '@/app/hooks/useClickOutside';
 import money from "@/app/localization/currency";
+import { useCart } from '@/app/hooks/useCart';
 
 
 export default function ScheduleCard({ franchise_id, schedule, modal = false, buttonAction = () => { }, }) {
     const { t } = useTranslation();
     const searchParams = useSearchParams();
+    const { addItem } = useCart();
 
     const [showDate, setShowDate] = useState(false);
     const [showLocation, setShowLocation] = useState(false);
@@ -204,11 +206,20 @@ export default function ScheduleCard({ franchise_id, schedule, modal = false, bu
                         </>}
                         {
                             (!modal &&
-                                !isFull ? ((!isExternal ? (isLoggedIn ? <button className={`${isWaitlist ? 'btn btn-warning rounded-0' : 'btn-style1'} mt-1 d-inline`} type="button" onClick={() => buttonAction(schedule.id, isWaitlist)}>
-                                    {!isWaitlist ? t('Enroll Now') : t('Join Waitlist')}
-                                </button> : <button className={`${isWaitlist ? 'btn btn-warning rounded-0' : 'btn-style1'} mt-1 d-inline`} id={`enroll-button-${schedule.id}`} type="button" data-bs-toggle="modal" data-bs-target={`#selectSchedule${schedule.id}`}>
-                                    {!isWaitlist ? t('Enroll Now') : t('Join Waitlist')}
-                                </button>) : <button className={`btn btn-warning rounded-0 mt-1 d-inline`} onClick={externalEnroll}>{t('External Enrollment')}</button>)) :
+                                !isFull ? ((!isExternal ? (
+                                    <>
+                                        {isLoggedIn ? <button className={`${isWaitlist ? 'btn btn-warning rounded-0' : 'btn-style1'} mt-1 d-inline`} type="button" onClick={() => buttonAction(schedule.id, isWaitlist)}>
+                                            {!isWaitlist ? t('Enroll Now') : t('Join Waitlist')}
+                                        </button> : <button className={`${isWaitlist ? 'btn btn-warning rounded-0' : 'btn-style1'} mt-1 d-inline`} id={`enroll-button-${schedule.id}`} type="button" data-bs-toggle="modal" data-bs-target={`#selectSchedule${schedule.id}`}>
+                                            {!isWaitlist ? t('Enroll Now') : t('Join Waitlist')}
+                                        </button>}
+                                        {isLoggedIn && !isWaitlist && (
+                                            <button className="btn btn-outline-primary rounded-0 mt-1 d-inline ms-1" type="button" onClick={() => addItem({ schedule_id: schedule.id, franchise_id, name: schedule.name, cost: schedule.cost, countryCode: schedule.countryCode })}>
+                                                {t('Add to Cart')}
+                                            </button>
+                                        )}
+                                    </>
+                                ) : <button className={`btn btn-warning rounded-0 mt-1 d-inline`} onClick={externalEnroll}>{t('External Enrollment')}</button>)) :
                                 <button className={`btn btn-secondary rounded-0 mt-1 d-inline`} type='button' disabled>{t('Schedule Full')}</button>
                             )
                         }
@@ -240,11 +251,20 @@ export default function ScheduleCard({ franchise_id, schedule, modal = false, bu
                                                     : t('No Available Spots')
                                             }
                                         </p>
-                                        {!isFull ? (isLoggedIn ? <button className={`${isWaitlist ? 'btn btn-warning rounded-0' : 'btn-style1'} mt-1 d-inline w-100`} type="button" onClick={() => buttonAction(schedule.id, isWaitlist)}>
-                                            {!isWaitlist ? t('Enroll Now') : t('Join Waitlist')}
-                                        </button> : <button className={`${isWaitlist ? 'btn btn-warning rounded-0' : 'btn-style1'} mt-1 d-inline w-100`} type="button" data-bs-toggle="modal" data-bs-target={`#selectSchedule${schedule.id}`}>
-                                            {!isWaitlist ? t('Enroll Now') : t('Join Waitlist')}
-                                        </button>) : <button className={`btn btn-secondary rounded-0 mt-1 d-inline`} type='button' disabled>{t('Schedule Full')}</button>
+                                        {!isFull ? (
+                                            <>
+                                                {isLoggedIn ? <button className={`${isWaitlist ? 'btn btn-warning rounded-0' : 'btn-style1'} mt-1 d-inline w-100`} type="button" onClick={() => buttonAction(schedule.id, isWaitlist)}>
+                                                    {!isWaitlist ? t('Enroll Now') : t('Join Waitlist')}
+                                                </button> : <button className={`${isWaitlist ? 'btn btn-warning rounded-0' : 'btn-style1'} mt-1 d-inline w-100`} type="button" data-bs-toggle="modal" data-bs-target={`#selectSchedule${schedule.id}`}>
+                                                    {!isWaitlist ? t('Enroll Now') : t('Join Waitlist')}
+                                                </button>}
+                                                {isLoggedIn && !isWaitlist && (
+                                                    <button className="btn btn-outline-primary rounded-0 mt-1 d-inline w-100" type="button" onClick={() => addItem({ schedule_id: schedule.id, franchise_id, name: schedule.name, cost: schedule.cost, countryCode: schedule.countryCode })}>
+                                                        {t('Add to Cart')}
+                                                    </button>
+                                                )}
+                                            </>
+                                        ) : <button className={`btn btn-secondary rounded-0 mt-1 d-inline`} type='button' disabled>{t('Schedule Full')}</button>
                                         }
                                     </> : <button className={`btn btn-warning rounded-0 mt-1 d-inline w-100`} onClick={externalEnroll}>{t('External Enrollment')}</button>}
                                 </>

--- a/src/app/components/Header.jsx
+++ b/src/app/components/Header.jsx
@@ -6,12 +6,14 @@ import initTranslations from '@/app/i18n';
 import AuthService from '@/auth.service';
 import alert from '@/app/components/SweetAlerts';
 import { useRouter } from 'next/navigation';
+import { useCart } from '@/app/hooks/useCart';
 
 export default function Header({ locale }) {
     const [t, setT] = useState(() => (key) => key);  // Default fallback translation (identity function)
     const [isAuthenticated, setIsAuthenticated] = useState(false);
 
     const router = useRouter();
+    const { items } = useCart();
 
     const logout = () => {
         AuthService.logout();
@@ -53,6 +55,14 @@ export default function Header({ locale }) {
                     <div className="col-lg-6 col-md-6 col-6">
                         <div className="d-flex gap-3 justify-content-end align-items-center">
                             {/* <LanguageChanger /> */}
+                            <div className="position-relative cursor-pointer" onClick={() => { router.push('/parent/cart'); }}>
+                                <i className="mdi mdi-cart fs-4 text-blue"></i>
+                                {items.length > 0 && (
+                                    <span className="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger">
+                                        {items.length}
+                                    </span>
+                                )}
+                            </div>
                             {isAuthenticated ? (
                                 <div className="profile">
                                     <div className="btn-group">

--- a/src/app/hooks/useCart.jsx
+++ b/src/app/hooks/useCart.jsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { createContext, useContext, useEffect, useState } from 'react';
+
+const CartContext = createContext({
+  franchise: null,
+  items: [],
+  addItem: () => {},
+  removeItem: () => {},
+  clearCart: () => {},
+});
+
+export const CartProvider = ({ children }) => {
+  const [cart, setCart] = useState({ franchise: null, items: [] });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const saved = localStorage.getItem('cart');
+    if (saved) {
+      try {
+        setCart(JSON.parse(saved));
+      } catch (err) {
+        console.error(err);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem('cart', JSON.stringify(cart));
+  }, [cart]);
+
+  const addItem = (item) => {
+    setCart((prev) => {
+      if (prev.franchise && prev.franchise !== item.franchise_id) {
+        return { franchise: item.franchise_id, items: [item] };
+      }
+      if (prev.items.find((i) => i.schedule_id === item.schedule_id)) return prev;
+      return { franchise: item.franchise_id, items: [...prev.items, item] };
+    });
+  };
+
+  const removeItem = (schedule_id) => {
+    setCart((prev) => ({
+      ...prev,
+      items: prev.items.filter((i) => i.schedule_id !== schedule_id),
+    }));
+  };
+
+  const clearCart = () => setCart({ franchise: null, items: [] });
+
+  return (
+    <CartContext.Provider value={{ ...cart, addItem, removeItem, clearCart }}>
+      {children}
+    </CartContext.Provider>
+  );
+};
+
+export const useCart = () => useContext(CartContext);


### PR DESCRIPTION
## Summary
- provide cart context with localStorage persistence
- show cart badge in header
- allow schedules to be added to cart
- expose cart page for parents
- wrap layout with CartProvider
- mark cart context as a client component
- add Add to Cart button in checkout page
- hide Add to Cart when user is not logged in or waitlist active
- ensure cart persists with franchise locking

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6853cacc7d848321af70cebcc0001505